### PR TITLE
Fix Socket.IO frontend compatibility

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1344,10 +1344,14 @@ function initRealtimeNotifications() {
     return;
   }
 
-  const socket = window.io(SOCKET_BASE);
+  const socket = window.location.origin === SOCKET_BASE ? io() : io(SOCKET_BASE);
 
   socket.on('connect', () => {
-    console.log('Socket.IO connected', socket.id);
+    console.log('Socket connected');
+  });
+
+  socket.on('disconnect', () => {
+    console.log('Socket disconnected');
   });
 
   socket.on('connect_error', (error) => {
@@ -1355,7 +1359,7 @@ function initRealtimeNotifications() {
   });
 
   socket.on('orion_notification', (payload) => {
-    console.log('Socket event: orion_notification', payload);
+    console.log('Notification received:', payload);
 
     try {
       if (!payload || typeof payload !== 'object') {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -250,7 +250,7 @@
     </section>
   </main>
 
-  <script src="http://localhost:5000/socket.io/socket.io.js"></script>
+  <script src="https://cdn.socket.io/4.7.2/socket.io.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Use Socket.IO client 4.7.2 in the frontend and improve connection/event logs so Orion notifications are received reliably from Flask-SocketIO.