### PR TITLE
feat: register external context providers on startup

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -136,6 +136,16 @@ At application startup, the backend shall register external context providers in
 - tweets
 
 These providers are served by the tutorial container applications.
+Registration behavior requirements:
+- Register two Orion registrations at startup via `POST /v2/registrations`:
+   - One registration for `temperature` and `relativeHumidity`.
+   - One registration for `tweets`.
+- Provider URL must be `http://tutorial:3000/api/v2` and `legacyForwarding` must be `true`.
+- Registration errors must be logged and must not crash backend startup.
+
+### FR-8.1 Registrations Inspection Endpoint
+The backend shall expose `GET /api/registrations` as a proxy to Orion `GET /v2/registrations`,
+returning Orion JSON payloads for verification and operational troubleshooting.
 
 ### FR-9. Orion Subscriptions
 The application shall create Orion subscriptions equivalent to the NGSIv2 subscriptions tutorial for:

--- a/architecture.md
+++ b/architecture.md
@@ -115,6 +115,11 @@ The backend is structured in logical layers:
 - Builds Orion subscription payloads for Product price changes and InventoryItem low stock.
 - Registers subscriptions at startup while avoiding duplicate creation.
 
+**app/services/context_provider_service.py** (Context Provider Registration Service):
+- Builds Orion registration payloads for external Store attributes.
+- Registers providers for `temperature`, `relativeHumidity`, and `tweets` at startup.
+- Uses isolated try/except handling per registration so startup never crashes on individual failures.
+
 **app/services/notification_event_service.py** (Notification Event Service):
 - Parses Orion notification payloads.
 - Emits Socket.IO events for supported event types.
@@ -127,6 +132,7 @@ The backend is structured in logical layers:
 - shelf_routes.py: Shelf CRUD endpoints (/api/shelves, /api/shelves/<id>)
 - inventory_item_routes.py: InventoryItem CRUD endpoints (/api/inventory-items, /api/inventory-items/<id>)
 - notification_routes.py: Orion callback endpoint (/api/notifications)
+- registration_routes.py: Orion registrations proxy endpoint (GET /api/registrations)
 - Blueprint-based modular design for future endpoint expansion
 
 Issue 1B/1C request processing flow:
@@ -317,6 +323,7 @@ Startup sequence requirements:
 2. Start Flask backend.
 3. Execute backend startup tasks:
   - Register subscriptions.
+  - Register external context providers (temperature, relativeHumidity, tweets).
 4. Open frontend UI.
 
 ## 9. Project Structure and Deployment Baseline (Issue #16)

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -14,6 +14,7 @@ from config import get_config
 from seed_data import seed_data
 from app.utils.logger import setup_logging, get_logger
 from app.socketio_instance import socketio
+from app.services.context_provider_service import register_all_context_providers
 from app.services import (
     OrionService,
     ProductService,
@@ -37,6 +38,7 @@ from app.routes import (
     shelf_bp,
     inventory_item_bp,
     notification_bp,
+    registration_bp,
 )
 
 
@@ -113,6 +115,7 @@ def create_app(config_name=None):
     app.register_blueprint(shelf_bp)
     app.register_blueprint(inventory_item_bp)
     app.register_blueprint(notification_bp)
+    app.register_blueprint(registration_bp)
     logger.debug("Health check and notification blueprints registered")
     
     # Register Orion subscriptions for price changes and low stock alerts
@@ -128,6 +131,13 @@ def create_app(config_name=None):
         logger.warning(f"Orion subscriptions registration skipped: Orion unavailable ({e})")
     except Exception as e:
         logger.warning(f"Orion subscriptions registration skipped due to error: {e}")
+
+    # Register Orion external context providers after subscription setup.
+    try:
+        register_all_context_providers(orion_service)
+        logger.info("Orion external context providers registered")
+    except Exception as e:
+        logger.warning(f"Orion context providers registration skipped due to error: {e}")
     
     # Register error handlers
     register_error_handlers(app)

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from .employee_routes import employee_bp
 from .shelf_routes import shelf_bp
 from .inventory_item_routes import inventory_item_bp
 from .notification_routes import notification_bp
+from .registration_routes import registration_bp
 
 __all__ = [
 	'health_bp',
@@ -16,4 +17,5 @@ __all__ = [
 	'shelf_bp',
 	'inventory_item_bp',
 	'notification_bp',
+	'registration_bp',
 ]

--- a/backend/app/routes/registration_routes.py
+++ b/backend/app/routes/registration_routes.py
@@ -1,0 +1,61 @@
+"""Registration routes for Orion context provider registrations."""
+
+from urllib.parse import urljoin
+
+import requests
+from flask import Blueprint, current_app, jsonify
+
+from app.utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+registration_bp = Blueprint('registrations', __name__, url_prefix='/api')
+
+
+@registration_bp.route('/registrations', methods=['GET'])
+def list_registrations():
+    """Proxy Orion registrations list to the frontend/backend clients."""
+    orion_service = current_app.orion_service
+    endpoint = urljoin(orion_service.base_url, '/v2/registrations')
+    headers = {
+        'Accept': 'application/json',
+        'Fiware-Service': orion_service.fiware_service,
+        'Fiware-ServicePath': orion_service.fiware_servicepath,
+    }
+
+    try:
+        response = orion_service.session.get(
+            endpoint,
+            headers=headers,
+            timeout=orion_service.timeout,
+        )
+    except requests.RequestException as exc:
+        logger.error(f"Failed to retrieve Orion registrations: {exc}")
+        return jsonify({
+            'error': 'ORION_CONNECTION_ERROR',
+            'message': str(exc),
+        }), 503
+
+    if response.status_code >= 400:
+        logger.warning(
+            f"Orion registrations proxy returned error {response.status_code}: {response.text}"
+        )
+        try:
+            return jsonify(response.json()), response.status_code
+        except ValueError:
+            return jsonify({
+                'error': 'ORION_API_ERROR',
+                'message': response.text,
+            }), response.status_code
+
+    try:
+        payload = response.json() if response.text else []
+    except ValueError:
+        logger.error('Orion registrations response is not valid JSON')
+        return jsonify({
+            'error': 'INVALID_ORION_RESPONSE',
+            'message': 'Orion returned a non-JSON registrations payload',
+        }), 502
+
+    return jsonify(payload), response.status_code

--- a/backend/app/services/context_provider_service.py
+++ b/backend/app/services/context_provider_service.py
@@ -1,0 +1,83 @@
+"""Startup registration of external context providers in Orion."""
+
+from urllib.parse import urljoin
+
+from app.utils.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+PROVIDER_URL = 'http://tutorial:3000/api/v2'
+
+
+def _build_store_environment_registration() -> dict:
+    """Build registration payload for Store temperature and humidity attributes."""
+    return {
+        'description': 'store-environment-context-provider',
+        'dataProvided': {
+            'entities': [{'type': 'Store', 'idPattern': '.*'}],
+            'attrs': ['temperature', 'relativeHumidity'],
+        },
+        'provider': {
+            'http': {'url': PROVIDER_URL},
+            'legacyForwarding': True,
+        },
+    }
+
+
+def _build_store_tweets_registration() -> dict:
+    """Build registration payload for Store tweets attribute."""
+    return {
+        'description': 'store-tweets-context-provider',
+        'dataProvided': {
+            'entities': [{'type': 'Store', 'idPattern': '.*'}],
+            'attrs': ['tweets'],
+        },
+        'provider': {
+            'http': {'url': PROVIDER_URL},
+            'legacyForwarding': True,
+        },
+    }
+
+
+def _get_json_headers(orion_service) -> dict:
+    """Build NGSIv2 JSON headers from Orion service settings."""
+    return {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'Fiware-Service': orion_service.fiware_service,
+        'Fiware-ServicePath': orion_service.fiware_servicepath,
+    }
+
+
+def register_all_context_providers(orion_service) -> None:
+    """Register all required external context providers in Orion.
+
+    Each registration is attempted independently so failures are logged but do
+    not stop backend startup.
+    """
+    endpoint = urljoin(orion_service.base_url, '/v2/registrations')
+    headers = _get_json_headers(orion_service)
+
+    registrations = (
+        ('temperature+relativeHumidity', _build_store_environment_registration()),
+        ('tweets', _build_store_tweets_registration()),
+    )
+
+    for label, payload in registrations:
+        try:
+            response = orion_service.session.post(
+                endpoint,
+                json=payload,
+                headers=headers,
+                timeout=orion_service.timeout,
+            )
+            response.raise_for_status()
+            registration_id = response.headers.get('Location', '').split('/')[-1] or 'unknown'
+            logger.info(
+                f"Registered Orion context provider for Store {label} (id={registration_id})"
+            )
+        except Exception as exc:
+            logger.error(
+                f"Failed to register Orion context provider for Store {label}: {exc}"
+            )

--- a/backend/seed_data.py
+++ b/backend/seed_data.py
@@ -6,6 +6,8 @@ Run with:
 
 from dotenv import load_dotenv
 
+from app.utils.ngsi_helpers import from_ngsi, to_ngsi
+
 
 def seed_data(app=None):
     """Seed initial Product, Store, Employee, Shelf and InventoryItem entities.
@@ -23,10 +25,10 @@ def seed_data(app=None):
 
     with flask_app.app_context():
         product_service = flask_app.product_service
-        store_service = flask_app.store_service
         employee_service = flask_app.employee_service
         shelf_service = flask_app.shelf_service
         inventory_item_service = flask_app.inventory_item_service
+        orion_service = flask_app.orion_service
 
         existing_products = product_service.list()
         if existing_products:
@@ -58,6 +60,9 @@ def seed_data(app=None):
                 'countryCode': 'ES',
                 'capacity': 1200,
                 'description': 'Main northern store',
+                'temperature': {'type': 'Float', 'value': 21.0},
+                'relativeHumidity': {'type': 'Float', 'value': 0.68},
+                'tweets': {'type': 'StructuredValue', 'value': []},
             },
             {
                 'id': 'store-002',
@@ -70,6 +75,9 @@ def seed_data(app=None):
                 'countryCode': 'ES',
                 'capacity': 1100,
                 'description': 'Main southern store',
+                'temperature': {'type': 'Float', 'value': 21.0},
+                'relativeHumidity': {'type': 'Float', 'value': 0.68},
+                'tweets': {'type': 'StructuredValue', 'value': []},
             },
             {
                 'id': 'store-003',
@@ -82,6 +90,9 @@ def seed_data(app=None):
                 'countryCode': 'ES',
                 'capacity': 1300,
                 'description': 'Main eastern store',
+                'temperature': {'type': 'Float', 'value': 21.0},
+                'relativeHumidity': {'type': 'Float', 'value': 0.68},
+                'tweets': {'type': 'StructuredValue', 'value': []},
             },
             {
                 'id': 'store-004',
@@ -94,6 +105,9 @@ def seed_data(app=None):
                 'countryCode': 'ES',
                 'capacity': 1250,
                 'description': 'Main western store',
+                'temperature': {'type': 'Float', 'value': 21.0},
+                'relativeHumidity': {'type': 'Float', 'value': 0.68},
+                'tweets': {'type': 'StructuredValue', 'value': []},
             },
         ]
 
@@ -149,7 +163,18 @@ def seed_data(app=None):
         ]
 
         created_products = [product_service.create(product) for product in products_data]
-        created_stores = [store_service.create(store) for store in stores_data]
+
+        created_stores = []
+        for store in stores_data:
+            ngsi_store = to_ngsi(store)
+            # Keep explicit NGSIv2 typing for external provider placeholders.
+            ngsi_store['temperature'] = store['temperature']
+            ngsi_store['relativeHumidity'] = store['relativeHumidity']
+            ngsi_store['tweets'] = store['tweets']
+
+            created_store = orion_service.create_entity('Store', ngsi_store)
+            created_stores.append(from_ngsi(created_store))
+
         created_employees = [employee_service.create(employee) for employee in employees_data]
 
         shelves_by_store = {}

--- a/data_model.md
+++ b/data_model.md
@@ -194,6 +194,16 @@ Store attributes temperature, relativeHumidity, and tweets are externally provid
 - Treated as standard Store attributes at query/render time.
 - `tweets` shall be modeled as `StructuredValue` to preserve provider payload structure.
 
+Seed initialization requirements for Store placeholders:
+- `temperature` must be initialized using explicit NGSIv2 shape: `{"type": "Float", "value": 21.0}`
+- `relativeHumidity` must be initialized using explicit NGSIv2 shape: `{"type": "Float", "value": 0.68}`
+- `tweets` must be initialized using explicit NGSIv2 shape: `{"type": "StructuredValue", "value": []}`
+
+Startup registration split:
+- Registration A: `Store.temperature`, `Store.relativeHumidity`
+- Registration B: `Store.tweets`
+- Both registrations use provider URL `http://tutorial:3000/api/v2` with `legacyForwarding=true`.
+
 ## 5.1 Subscription Trigger Implementation Clarification
 
 Trigger behavior for `Product.price` and `InventoryItem.stockCount` is implemented through Orion subscriptions.


### PR DESCRIPTION
## Summary\n- add startup registration service for external Store context providers\n- register providers for temperature/relativeHumidity and tweets after subscription setup\n- add GET /api/registrations proxy endpoint\n- seed Store placeholders using explicit NGSIv2 format for temperature, relativeHumidity and tweets\n- update PRD.md, architecture.md and data_model.md\n\nCloses #18