### PR TITLE
docs: align PRD, architecture and data_model after Issue 4 merge

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -128,6 +128,11 @@ The Stores Map view shall:
 - Show a hover card with image and key Store attributes.
 - Navigate to Store detail when a Store marker/image is clicked.
 
+Current implemented state after Issue 4:
+- Navigation includes a Stores Map tab.
+- The Stores Map view is currently an empty placeholder section.
+- Full Leaflet implementation remains pending for its dedicated issue.
+
 ## 4.4 NGSIv2 Registrations, Subscriptions, and Notifications
 
 ### FR-8. External Context Providers Registration
@@ -356,9 +361,28 @@ Real-time delivery status:
 - Backend notification reception and forwarding are implemented with Flask-SocketIO.
 - Frontend client receives `orion_notification` events and updates the notifications UI in real time.
 
+Frontend (Issue 4 - Global UX theme system):
+- Manchester United design system implemented with CSS custom properties:
+   - `--color-primary: #DA020E`
+   - `--color-primary-dark: #8B0000`
+   - `--color-secondary: #FFD700`
+   - `--color-white: #FFFFFF`
+   - `--color-black: #1A1A1A`
+   - `--color-surface: #F8F8F8`
+   - `--font-heading: 'Bebas Neue', sans-serif`
+   - `--font-body: 'Inter', sans-serif`
+- Dark/Light mode toggle implemented through `html[data-theme="dark"]` and persisted with `localStorage`.
+- EN/ES i18n system implemented using a frontend translations object and `data-i18n` attributes.
+- Sticky global navigation bar implemented with 5 links:
+   - Home
+   - Products
+   - Stores
+   - Employees
+   - Stores Map (placeholder)
+- Known exception: form tags were intentionally kept to preserve native HTML5 validation behavior and existing input constraints.
+
 ### 8.2 Pending Features
 
-- Frontend Socket.IO client integration and in-UI real-time notification rendering.
 - Store map view (Leaflet) and store-detail map section.
 - Three.js immersive store visualization.
-- Advanced UI features requested by assignment (full iconography set, bilingual i18n toggle, dark/light mode polish, advanced visuals).
+- Advanced UI features requested by assignment that are not yet completed beyond Issue 4 baseline.

--- a/architecture.md
+++ b/architecture.md
@@ -33,11 +33,19 @@ Interpretation:
 
 ## 3.1 Frontend (HTML/CSS/JavaScript)
 Responsibilities:
-- Render views: Home, Products, Stores, and Employees.
+- Render views: Home, Products, Stores, Employees, and Stores Map placeholder.
 - Render entity tables and Store detail grouped inventory view.
 - Execute CRUD actions through fetch-based REST calls to backend endpoints.
 - Render Store detail using DOM logic with hierarchy Store -> Shelves -> InventoryItems.
 - Execute Store detail actions (add Shelf, add InventoryItem, buy product).
+- Apply global UX state and localization behavior:
+  - Manchester United design tokens through CSS custom properties.
+  - Dark/Light mode toggling by updating `html[data-theme]`.
+  - EN/ES translation application using `data-i18n` attributes and a JavaScript translations object.
+  - Persist user theme and language preferences in `localStorage`.
+
+Issue 4 implementation note:
+- Form tags were intentionally kept as a known exception to preserve native HTML5 validation behavior.
 
 Key design constraints:
 - No frontend framework.
@@ -308,6 +316,23 @@ The diagram highlights the current implemented production flow.
   - Add Shelf, Add InventoryItem, and Buy product actions.
 - Employees view:
   - Employee table CRUD with category and skills.
+- Stores Map view:
+  - Navigation target and placeholder section are implemented.
+  - Full map rendering remains pending for the dedicated map issue.
+
+## 6.1 Global UX System (Issue 4)
+
+- Sticky navbar:
+  - Implemented as top-level sticky header with active-link highlighting.
+  - Includes 5 navigation links: Home, Products, Stores, Employees, Stores Map.
+- Theme architecture:
+  - Base theme tokens declared in `:root`.
+  - Dark mode overrides declared under `html[data-theme="dark"]`.
+  - Theme toggle updates only state attributes/classes, with no HTML injection.
+- Internationalization architecture:
+  - Text resources are centralized in a frontend `translations` object with `en` and `es` namespaces.
+  - `applyTranslations(lang)` iterates through translatable nodes (`data-i18n`) and updates text values.
+  - Language selection persists across sessions using `localStorage`.
 
 ## 7. Architectural Constraints and Quality Decisions
 

--- a/data_model.md
+++ b/data_model.md
@@ -330,6 +330,22 @@ This initialization baseline ensures all mandatory UI views and grouping behavio
 
 - Frontend real-time notification consumption and advanced visualization layers do not alter this entity model and remain outside current implemented UI scope.
 
+## 10.3 Issue 4 UX Alignment (Non-Entity State)
+
+Issue 4 introduced global frontend UX behavior that does not modify NGSI entity schemas but affects UI-level state representation:
+
+- Theme state:
+  - Persisted in browser `localStorage`.
+  - Applied via `html[data-theme="dark"]` and CSS custom property overrides.
+- Language state:
+  - Persisted in browser `localStorage`.
+  - Applied through EN/ES translation keys mapped to DOM nodes using `data-i18n` attributes.
+- Navigation model at UI layer:
+  - Global sticky navbar with 5 sections: Home, Products, Stores, Employees, Stores Map.
+  - Stores Map is currently a placeholder section; no new entity relationships were added.
+- Known exception for validation integrity:
+  - Existing HTML form tags were intentionally retained so native HTML5 validation attributes and constraints remain authoritative.
+
 ## 11. Project-Structure Alignment Note (Issue #16)
 
 This issue introduces no data-model/entity-schema changes.


### PR DESCRIPTION
## Summary\n- align PRD.md, architecture.md, and data_model.md with Issue 4 implementation\n- document Manchester United theme tokens, dark/light localStorage persistence, EN/ES translations object, sticky 5-link navbar, and Stores Map placeholder\n- record known exception: form tags intentionally kept to preserve native HTML5 validation\n\n## Files\n- PRD.md\n- architecture.md\n- data_model.md