### PR TITLE
docs: reflect Stores Map Leaflet implementation across PRD architecture and data model

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -87,8 +87,7 @@ Implemented state after Issue 5:
 
 ### FR-4. Store Detail View
 The Store detail page shall include all items below:
-1. Store location rendered on a map using Leaflet. Implemented in Issue 8.
-2. Immersive virtual tour of the Store using Three.js, showing Shelves and contained Products, including:
+1. Immersive virtual tour of the Store using Three.js, showing Shelves and contained Products, including:
    - Units per shelf
    - Total stock units
 3. InventoryItems table grouped by Shelf:
@@ -126,7 +125,7 @@ Implemented state after Issue 6:
 - Store detail includes a tweets section rendered from Store `tweets` data with an X/Twitter icon per item.
 - Store notifications are displayed inside a dedicated panel container with Manchester United red left-border styling.
 - Three.js immersive store tour is now implemented in Issue 7 with lazy-loaded CDN modules, interactive hover inspection, and canvas-scoped cleanup.
-- Leaflet map remains pending for Issue 8.
+- Store geolocation data is consumed by the Stores Map tab (Issue 8) for Leaflet marker rendering and map-to-detail navigation.
 
 ## 4.3 Home and Global Navigation
 
@@ -146,10 +145,11 @@ The Stores Map view shall:
 - Show a hover card with image and key Store attributes.
 - Navigate to Store detail when a Store marker/image is clicked.
 
-Current implemented state after Issue 4:
-- Navigation includes a Stores Map tab.
-- The Stores Map view is currently an empty placeholder section.
-- Full Leaflet implementation remains pending for its dedicated issue.
+Current implemented state after Issue 8:
+- Navigation includes an active Stores Map tab.
+- The view renders a Leaflet map using OpenStreetMap tiles and Store image markers.
+- Hovering a marker shows a pre-rendered info card (image, name, country, temperature, humidity).
+- Clicking a marker navigates to Stores view and loads the selected Store detail context.
 
 ## 4.4 NGSIv2 Registrations, Subscriptions, and Notifications
 
@@ -343,7 +343,7 @@ Backend (Issues 1C, 2A, 2B):
 - SubscriptionService implemented and executed at startup to register Orion subscriptions (price change and low stock).
 - Notification callback endpoint implemented at `/api/notifications`.
 - Notifications are received and logged successfully.
-- Socket.IO frontend propagation remains pending for a future iteration.
+- Socket.IO frontend propagation is implemented and active in the browser UI.
 
 Frontend (Issues 2C, 2D + Store detail completion):
 - Base frontend implemented as vanilla HTML/CSS/JavaScript (no frameworks).
@@ -398,10 +398,9 @@ Frontend (Issue 4 - Global UX theme system):
    - Products
    - Stores
    - Employees
-   - Stores Map (placeholder)
+   - Stores Map
 - Known exception: form tags were intentionally kept to preserve native HTML5 validation behavior and existing input constraints.
 
 ### 8.2 Pending Features
 
-- Store map view (Leaflet) and store-detail map section.
-- Advanced UI features requested by assignment that are not yet completed beyond the implemented Store detail tour and Issue 4 baseline.
+- Advanced UI features requested by assignment that are not yet completed beyond the implemented Store detail tour, Stores Map tab, and Issue 4 baseline.

--- a/architecture.md
+++ b/architecture.md
@@ -33,7 +33,7 @@ Interpretation:
 
 ## 3.1 Frontend (HTML/CSS/JavaScript)
 Responsibilities:
-- Render views: Home, Products, Product detail, Stores, Employees, and Stores Map placeholder.
+- Render views: Home, Products, Product detail, Stores, Employees, and Stores Map.
 - Render entity tables and Store detail grouped inventory view.
 - Render Product detail inventory grouped by Store with Shelf sub-rows.
 - Execute CRUD actions through fetch-based REST calls to backend endpoints.
@@ -41,6 +41,9 @@ Responsibilities:
 - Render Store detail weather and social context blocks (temperature, relativeHumidity, tweets).
 - Render Store detail photo container with CSS-only rotate+zoom hover animation.
 - Render Store detail immersive tour with lazy-loaded Three.js, OrbitControls, and Raycaster hover inspection.
+- Render Stores Map with Leaflet (CDN), OpenStreetMap tiles, and custom Store image markers.
+- Handle Stores Map hover card behavior using pre-existing DOM nodes and CSS class toggling.
+- Handle Stores Map marker click-through navigation to Stores view with selected Store detail loading.
 - Render Product detail using DOM template-row cloning (Store group row + Shelf row templates).
 - Execute Store detail actions (add Shelf, add InventoryItem, buy product).
 - Execute Product detail action to add InventoryItem to an eligible Shelf in the selected Store group.
@@ -237,10 +240,7 @@ Primary channel:
 
 Current status:
 - Backend Socket.IO emission is implemented.
-- Frontend Socket.IO client consumption is pending.
-
-Update:
-- Frontend Socket.IO client consumption is now implemented.
+- Frontend Socket.IO client consumption is implemented.
 - Real-time notification delivery is active from Orion to backend to connected browsers.
 
 ## Orion -> Backend -> Frontend Real-Time Flow
@@ -336,8 +336,8 @@ The diagram highlights the current implemented production flow.
 - Employees view:
   - Employee table CRUD with category and skills.
 - Stores Map view:
-  - Navigation target and placeholder section are implemented.
-  - Full map rendering remains pending for the dedicated map issue.
+  - Leaflet map rendered from Store geolocation data.
+  - Custom Store image markers, hover info card, and click-through to Stores detail are implemented.
 
 ## 6.1 Global UX System (Issue 4)
 

--- a/data_model.md
+++ b/data_model.md
@@ -37,6 +37,11 @@ Operational/base attributes needed by required views:
 - address: StructuredValue (postal address)
 - location: geo:json Point (latitude/longitude)
 
+Stores Map usage notes (Issue 8):
+- `location` is required to place Store markers on the Leaflet map.
+- `image` is used as marker visual content and hover-card image.
+- `countryCode`, `temperature`, and `relativeHumidity` are rendered in the map hover card.
+
 Issue 1B backend CRUD fields for Store:
 - name
 - image
@@ -177,12 +182,13 @@ Additional contextual relation used in data access:
 1. countryCode must be exactly two characters.
 2. skills must contain only allowed enum values.
 3. Product color must be stored as RGB hexadecimal text.
-4. An Employee must always reference one valid Store.
-5. A Shelf must always reference one valid Store.
-6. An InventoryItem must reference valid Product, Shelf, and Store entities.
-7. In Product detail view, adding InventoryItem is limited to Shelves in the selected Store that do not already contain that Product.
-8. In Product detail view, a newly created InventoryItem starts with `shelfCount=1` and `stockCount=1`.
-9. In Store detail view, adding InventoryItem to Shelf is limited to Products not already present in that Shelf.
+4. Store `location` should contain valid numeric longitude and latitude values for map rendering.
+5. An Employee must always reference one valid Store.
+6. A Shelf must always reference one valid Store.
+7. An InventoryItem must reference valid Product, Shelf, and Store entities.
+8. In Product detail view, adding InventoryItem is limited to Shelves in the selected Store that do not already contain that Product.
+9. In Product detail view, a newly created InventoryItem starts with `shelfCount=1` and `stockCount=1`.
+10. In Store detail view, adding InventoryItem to Shelf is limited to Products not already present in that Shelf.
 
 Issue 1C backend enforcement scope for constraints 4-6:
 - Relationship validation checks only that referenced entities exist in Orion.


### PR DESCRIPTION
Closes #40\n\n## Summary\n- Update PRD to reflect implemented Stores Map tab behavior\n- Update architecture docs for Leaflet map rendering, hover card, and click-through navigation\n- Update data model docs with map-related Store attribute usage and location constraint\n\n## Files\n- PRD.md\n- architecture.md\n- data_model.md